### PR TITLE
Update DAPNET credentials in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Das Projekt *FrühstücksBrunchManager* ist eine Flask-basierte Webanwendung, di
    ```
    pip install -r requirements.txt
    ```
-3. Erstellen Sie eine `.pwd`-Datei im Hauptverzeichnis mit den Admin-Anmeldedaten im Format:
+3. Erstellen Sie eine `.pwd`-Datei im Hauptverzeichnis mit den Admin-Anmeldedaten sowie den DAPNET-Zugangsdaten im Format (alle vier Einträge werden benötigt):
    ```
    ADMIN_1:ADMIN_PASSWORD_1
    ADMIN_2:ADMIN_PASSWORD_2
+   dapnet_username:DAPNET_USER
+   dapnet_password:DAPNET_PASS
    ```
 4. Starte die Anwendung:
    ```


### PR DESCRIPTION
## Summary
- describe the required DAPNET credentials in the installation section of the README

## Testing
- `python -m py_compile brunch.py`

------
https://chatgpt.com/codex/tasks/task_e_68417ce49dd08321bec55c4382bf15f8