### PR TITLE
Fix email validation regex

### DIFF
--- a/brunch.py
+++ b/brunch.py
@@ -243,7 +243,7 @@ def validate_bringalong(text):
 
 # Funktion zur Überprüfung der E-Mail-Adresse
 def validate_email(email):
-    return re.match(r'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}$', email) is not None
+    return re.match(r'^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$', email) is not None
 
 def read_items_from_file():
     try:


### PR DESCRIPTION
## Summary
- update email regex to avoid using a character class with pipe

## Testing
- `pytest -q`
- `python -m py_compile brunch.py`

------
https://chatgpt.com/codex/tasks/task_e_68417cdf19ac8321913729e7e3d45ab9