### PR TITLE
Fix Werkzeug incompatibility with Flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.1.2
+Werkzeug<3
 pytz==2022.1
 reportlab==3.6.9


### PR DESCRIPTION
## Summary
- pin Werkzeug to a version below 3 to maintain compatibility with Flask 2.1

## Testing
- `python -m py_compile brunch.py`

------
https://chatgpt.com/codex/tasks/task_e_68417b889558832183c1e6a7b639ce4e