### PR TITLE
Remove hard-coded date exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,14 @@ Das Projekt *FrühstücksBrunchManager* ist eine Flask-basierte Webanwendung, di
 ## Benutzung
 Öffne deinen Webbrowser und gehe zu `http://localhost:8082/`, um die Anwendung zu verwenden. Für den Zugriff auf den Admin-Bereich `http://localhost:8082/admin` ist eine Authentifizierung erforderlich.
 
+## Abweichende Termine
+Sondertermine müssen nicht im Code gepflegt werden. Im Admin-Bereich gibt es
+ein Feld **Abweichendes Datum**, über das sich das Datum des nächsten Brunches
+ändern lässt. Trage hier ein Datum im Format `TT.MM.JJJJ` ein, um einen von der
+Regel abweichenden Termin festzulegen. Setze optional das Kontrollkästchen
+**Nächsten Termin ausfallen lassen**, um das Treffen komplett abzusagen. Bei
+abweichenden oder abgesagten Terminen erscheint automatisch ein Hinweistext auf
+der Startseite.
+
 ## Autor
 Erik Schauer, DO1FFE - do1ffe@darc.de


### PR DESCRIPTION
## Summary
- delete hard-coded brunch exception date
- simplify logic for special date checks
- show notices when brunch is cancelled or rescheduled

## Testing
- `python -m py_compile brunch.py`


------
https://chatgpt.com/codex/tasks/task_e_687e0620737c83219fae0151415680e1