### PR TITLE
Fix /admin/add duplication check

### DIFF
--- a/brunch.py
+++ b/brunch.py
@@ -585,6 +585,8 @@ def admin_add_participant():
     )
 
     if request.method == 'POST':
+        # Aktuelle Daten berücksichtigen, falls andere Teilnehmer zwischenzeitlich etwas eingetragen haben
+        taken_items_info = db_manager.get_brunch_info()
         name = request.form.get('name', '').strip()
         email = request.form.get('email', '').strip()
         selected_item = request.form.get('selected_item', '').strip()


### PR DESCRIPTION
## Summary
- refresh taken item list when submitting admin add form so items chosen by other participants are considered

## Testing
- `python -m py_compile brunch.py`

------
https://chatgpt.com/codex/tasks/task_e_687e11a0e8948321b4891d286b3b3bc3