### PR TITLE
Fix automated DB reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,8 @@ Sonntage. Setze optional das Kontrollkästchen
 abweichenden oder abgesagten Terminen erscheint automatisch ein Hinweistext auf
 der Startseite.
 
+Die Datenbank der Anmeldungen wird jeweils um 15:00 Uhr des eingestellten
+Brunch-Termins automatisch geleert. Dies gilt auch für verschobene Termine.
+
 ## Autor
 Erik Schauer, DO1FFE - do1ffe@darc.de

--- a/brunch.py
+++ b/brunch.py
@@ -1024,7 +1024,11 @@ def reset_db():
         return jsonify({"error": str(e)}), 500
 
 # Starten des Threads zur Überwachung und zum Zurücksetzen der Datenbank
-reset_thread = threading.Thread(target=schedule_database_reset)
+# Nutzt reset_database_at_event_time, um die Datenbank pünktlich zum Ende des
+# Brunchs zu leeren. Diese Implementierung prüft minütlich, ob das gesetzte
+# Veranstaltungsdatum überschritten wurde und vermeidet dadurch Verzögerungen
+# durch eine stündliche Überprüfung.
+reset_thread = threading.Thread(target=reset_database_at_event_time)
 reset_thread.daemon = True  # Markieren Sie den Thread als Daemon, damit er automatisch beendet wird, wenn das Hauptprogramm beendet wird.
 reset_thread.start()
 


### PR DESCRIPTION
## Summary
- use more accurate DB reset scheduler
- document automatic reset timing

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile brunch.py`
- `pip check`


------
https://chatgpt.com/codex/tasks/task_e_688626dc2864832194ff1af366b8584b