### PR TITLE
Fix clearing override after DB reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ der Startseite.
 
 Die Datenbank der Anmeldungen wird jeweils um 15:00 Uhr des eingestellten
 Brunch-Termins automatisch geleert. Dies gilt auch für verschobene Termine.
+Nach dem Reset wird ein gesetzter Sondertermin entfernt, damit automatisch das
+nächste reguläre Datum angezeigt wird.
 
 ## Autor
 Erik Schauer, DO1FFE - do1ffe@darc.de


### PR DESCRIPTION
## Summary
- reset special date and cancellation flag when database resets
- update manual reset route similarly
- document clearing of special date after automatic reset

## Testing
- `python -m py_compile brunch.py`

------
https://chatgpt.com/codex/tasks/task_e_68862887a82c8321b042380cc8415e0a