### PR TITLE
Fix: Verhindere vorzeitiges wiederholtes Löschen von Brunch-Einträgen

### DIFF
--- a/brunch.py
+++ b/brunch.py
@@ -340,13 +340,16 @@ def should_reset_database():
     current_brunch_str = current_brunch_date()
     current_brunch = berlin_tz.localize(datetime.strptime(current_brunch_str, '%d.%m.%Y'))
     reset_time = current_brunch.replace(hour=15, minute=0, second=0, microsecond=0)
+    last_reset_for_date = db_manager.get_config('last_reset_for_date')
 
-    return now > reset_time
+    return now > reset_time and last_reset_for_date != current_brunch_str
 
 def reset_database_if_needed():
     if should_reset_database():
+        current_brunch_str = current_brunch_date()
         save_participant_log()
         db_manager.reset_db()
+        db_manager.set_config('last_reset_for_date', current_brunch_str)
         db_manager.clear_special_dates()
         
 def schedule_database_reset():
@@ -1019,11 +1022,13 @@ def save_participant_log():
 def reset_database_at_event_time():
     while True:
         if should_reset_database():
+            current_brunch_str = current_brunch_date()
             # Speichern der Teilnehmerinformationen in eine Log-Datei
             save_participant_log()
 
             # Zurücksetzen der Datenbank
             db_manager.reset_db()
+            db_manager.set_config('last_reset_for_date', current_brunch_str)
             db_manager.clear_special_dates()
             logger.debug("Datenbank wurde resettet.")
 


### PR DESCRIPTION
## Zusammenfassung
- Fehler behoben, bei dem Teilnehmer-Einträge nach einem bereits erfolgten Monats-Reset bis zum nächsten Termin erneut gelöscht werden konnten.
- `should_reset_database()` prüft jetzt zusätzlich, ob für den aktuellen Termin bereits ein Reset durchgeführt wurde.
- Beim automatischen Reset wird das verarbeitete Termin-Datum in `config.last_reset_for_date` gespeichert.

## Technische Details
- Datei: `brunch.py`
- Neue Schutzlogik:
  - `last_reset_for_date = db_manager.get_config('last_reset_for_date')`
  - Reset nur, wenn `now > reset_time` **und** `last_reset_for_date != current_brunch_str`
- Persistenz des Reset-Markers an beiden Reset-Pfaden:
  - `reset_database_if_needed()`
  - `reset_database_at_event_time()`

## Warum der Fehler auftrat
Nach dem ersten Reset blieb die Bedingung `now > reset_time` für den restlichen Monat wahr. Dadurch konnte die Hintergrundschleife neue Einträge vor dem nächsten eigentlichen Termin wieder löschen.

## Verifikation
- `python -m py_compile brunch.py` erfolgreich ausgeführt (Syntaxprüfung).
- Anschließend Code-Stellen mit `rg` geprüft, um sicherzustellen, dass Marker-Lesen und -Schreiben an allen relevanten Stellen vorhanden ist.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc6e18dae8832195c4e3dde55e0dd1)